### PR TITLE
Size center view controller to bounds

### DIFF
--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -232,7 +232,7 @@ typedef enum {
     
     [self addChildViewController:_centerViewController];
     [self.view addSubview:[_centerViewController view]];
-    [((UIViewController *)_centerViewController) view].frame = (CGRect){.origin = origin, .size=centerViewController.view.frame.size};
+    [((UIViewController *)_centerViewController) view].frame = self.view.bounds;
     
     [_centerViewController didMoveToParentViewController:self];
     


### PR DESCRIPTION
Parent VCs are responsible for setting the frame of their child views and shouldn't blindly use their current origin and size.